### PR TITLE
v1.0.1 - Add France joke, start management command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,6 @@ A core plugin for the Not-yet-named Server.
 ## Features
 Current list, subject to change or me forgetting to change it.
 - Welcome message on join
-- Day counter command
+- Day counter command (`/daycounter`)
+- Simple management command (`/nncore`)
+- France Isn't Real (It's an inside joke)

--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,8 @@ plugins {
     id 'java'
 }
 
-group = 'com.bownet'
-version = '1.0.0'
+group = 'com.aelithron'
+version = '1.0.1'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/aelithron/nonamecore/CoreTools.java
+++ b/src/main/java/com/aelithron/nonamecore/CoreTools.java
@@ -1,4 +1,4 @@
-package com.bowfun.nonamecore;
+package com.aelithron.nonamecore;
 
 import org.bukkit.ChatColor;
 

--- a/src/main/java/com/aelithron/nonamecore/DayCounterCMD.java
+++ b/src/main/java/com/aelithron/nonamecore/DayCounterCMD.java
@@ -1,4 +1,4 @@
-package com.bowfun.nonamecore;
+package com.aelithron.nonamecore;
 
 import org.bukkit.ChatColor;
 import org.bukkit.World;

--- a/src/main/java/com/aelithron/nonamecore/ManageCMD.java
+++ b/src/main/java/com/aelithron/nonamecore/ManageCMD.java
@@ -1,0 +1,64 @@
+package com.aelithron.nonamecore;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ManageCMD implements CommandExecutor {
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        String prefix = CoreTools.getInstance().getPrefix();
+
+        if (!sender.hasPermission("nncore.manage")) {
+            sender.sendMessage(prefix + ChatColor.RED + "You don't have permission to do this!");
+            return false;
+        }
+
+        if (args.length == 0) {
+            sender.sendMessage(prefix + ChatColor.GREEN + "To see what you can do, run /nncore check.");
+            return false;
+        }
+
+        if (args[0].equalsIgnoreCase("check")) {
+            sender.sendMessage(prefix + ChatColor.DARK_AQUA + "Checking possible actions...");
+            // Map of permissions and features
+            Map<String, String> permissionMap = new HashMap<>();
+            permissionMap.put("nncore.manage.reload", "/nncore reload: Reloads the plugin");
+
+            boolean hasPermission = false;
+
+            // Loop through the map and check permissions
+            for (Map.Entry<String, String> entry : permissionMap.entrySet()) {
+                if (sender.hasPermission(entry.getKey())) {
+                    sender.sendMessage(ChatColor.AQUA + entry.getValue());
+                    hasPermission = true;
+                }
+            }
+
+            if (!hasPermission) {
+                sender.sendMessage(ChatColor.RED + "You don't have permission to perform any actions.");
+                sender.sendMessage(ChatColor.AQUA + "This is likely a misconfiguration, as you have management permissions but no feature permissions.");
+            }
+        }
+
+        return false;
+    }
+
+    private void noPermission(CommandSender sender, String prefix) {
+        sender.sendMessage(prefix + ChatColor.RED + "You don't have permission to do this!");
+        sender.sendMessage(ChatColor.GREEN + "To see what you can do, run /nncore check.");
+    }
+
+    private boolean checkFeature(ManagementFeature feature) {
+        feature.name();
+        return false;
+    }
+
+    private enum ManagementFeature {
+        reload
+    }
+}

--- a/src/main/java/com/aelithron/nonamecore/NoNameCore.java
+++ b/src/main/java/com/aelithron/nonamecore/NoNameCore.java
@@ -1,9 +1,10 @@
-package com.bowfun.nonamecore;
+package com.aelithron.nonamecore;
 
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -24,6 +25,7 @@ public final class NoNameCore extends JavaPlugin implements Listener {
         CoreTools.getInstance().setPlugin(this);
         // Commands
         getCommand("daycounter").setExecutor(new DayCounterCMD());
+        getCommand("nncore").setExecutor(new ManageCMD());
     }
 
     @EventHandler
@@ -49,5 +51,13 @@ public final class NoNameCore extends JavaPlugin implements Listener {
                 }
             }
         }, 60L);
+    }
+
+    @EventHandler
+    public void playerChat(AsyncPlayerChatEvent e) {
+        // France joke
+        if ((e.getMessage().equalsIgnoreCase("France") || e.getMessage().equalsIgnoreCase("French")) && (getConfig().getBoolean("FranceJoke"))) {
+            e.getPlayer().sendMessage(ChatColor.DARK_RED + ChatColor.BOLD.toString() + "FRANCE ISN'T REAL");
+        }
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,4 @@
-# NoNameCore by BowFun
+# NoNameCore by Aelithron
 # A core plugin to add extras to the Not-yet-named Server.
 
 # Prefix - Starts every message sent by the plugin.
@@ -11,6 +11,11 @@ Prefix: "&8[&dNo Name Core&8]"
 # Placeholder %allplayers% for all online players
 WelcomeMessage:
   - "&8-- &dNot-yet-named Server &8--"
-  - "&bJoin Proximity Chat: /voice"
   - "&9Join the Discord: /discord"
   - "&aPlayers online: &f%allplayers%"
+
+# France Joke
+# This is an inside joke on our server.
+# Disabled by default, change the below value to true to enable.
+# If enabled, sends a message to a player when they send only the word France/French in chat.
+FranceJoke: false

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,14 +1,18 @@
 name: NoNameCore
 version: '${version}'
-main: com.bowfun.nonamecore.NoNameCore
+main: com.aelithron.nonamecore.NoNameCore
 api-version: '1.21'
 prefix: No Name Core
-authors: [BowFun]
+authors: [Aelithron]
 description: A core plugin for the Not-yet-named Server.
-website: plugins.bownet.xyz
 commands:
   daycounter:
     aliases:
       - daycount
       - wtime
     description: Restores the day counter from F3 (+ bedrock support)
+  nncore:
+    aliases:
+      - nnc
+      - nonamecore
+    description: Manage the No Name Core plugin.


### PR DESCRIPTION
Created a very easy-to-extend /nncore command for plugin management, soon to extend to server management, in ManageCMD. Also, created a FranceJoke feature, where the plugin will make the Rule 6 joke when a player says "France" or "French". Set to disabled by default, enable in config.yml. (for those not members of our server, Rule 6 is that "To play on this server, you must accept that France isn't real.") Finally, transitions the plugin over to the Aelithron name, as I have taken over this project from the previous maintainer :3