### PR TITLE
v1.0.1 part 2 - Add reload to ManageCMD, add /rules aka RulesCMD

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,5 @@ Current list, subject to change or me forgetting to change it.
 - Welcome message on join
 - Day counter command (`/daycounter`)
 - Simple management command (`/nncore`)
-- France Isn't Real (It's an inside joke)
+- Rule listing command (`/rules`)
+- France Isn't Real (It's an inside joke, disabled by default)

--- a/src/main/java/com/aelithron/nonamecore/ManageCMD.java
+++ b/src/main/java/com/aelithron/nonamecore/ManageCMD.java
@@ -9,6 +9,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class ManageCMD implements CommandExecutor {
+    private NoNameCore plugin;
+    public ManageCMD(NoNameCore plugin) {
+        this.plugin = plugin;
+    }
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         String prefix = CoreTools.getInstance().getPrefix();
@@ -31,7 +35,6 @@ public class ManageCMD implements CommandExecutor {
 
             boolean hasPermission = false;
 
-            // Loop through the map and check permissions
             for (Map.Entry<String, String> entry : permissionMap.entrySet()) {
                 if (sender.hasPermission(entry.getKey())) {
                     sender.sendMessage(ChatColor.AQUA + entry.getValue());
@@ -45,20 +48,23 @@ public class ManageCMD implements CommandExecutor {
             }
         }
 
+        if (args[0].equalsIgnoreCase("reload")) {
+            if (sender.hasPermission("nncore.manage.reload")) {
+                plugin.reloadConfig();
+                sender.sendMessage(prefix + ChatColor.GREEN + "Config reloaded!");
+                return true;
+            } else {
+                noPermission(sender, prefix);
+                return false;
+            }
+        }
+        sender.sendMessage(prefix + ChatColor.RED + "Incorrect usage!");
+        sender.sendMessage(ChatColor.GREEN + "To see what you can do, run /nncore check.");
         return false;
     }
 
     private void noPermission(CommandSender sender, String prefix) {
         sender.sendMessage(prefix + ChatColor.RED + "You don't have permission to do this!");
         sender.sendMessage(ChatColor.GREEN + "To see what you can do, run /nncore check.");
-    }
-
-    private boolean checkFeature(ManagementFeature feature) {
-        feature.name();
-        return false;
-    }
-
-    private enum ManagementFeature {
-        reload
     }
 }

--- a/src/main/java/com/aelithron/nonamecore/NoNameCore.java
+++ b/src/main/java/com/aelithron/nonamecore/NoNameCore.java
@@ -25,7 +25,8 @@ public final class NoNameCore extends JavaPlugin implements Listener {
         CoreTools.getInstance().setPlugin(this);
         // Commands
         getCommand("daycounter").setExecutor(new DayCounterCMD());
-        getCommand("nncore").setExecutor(new ManageCMD());
+        getCommand("nncore").setExecutor(new ManageCMD(this));
+        getCommand("rules").setExecutor(new RulesCMD(this));
     }
 
     @EventHandler

--- a/src/main/java/com/aelithron/nonamecore/RulesCMD.java
+++ b/src/main/java/com/aelithron/nonamecore/RulesCMD.java
@@ -1,0 +1,26 @@
+package com.aelithron.nonamecore;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+public class RulesCMD implements CommandExecutor {
+    private NoNameCore plugin;
+    public RulesCMD(NoNameCore plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        String prefix = CoreTools.getInstance().getPrefix();
+        sender.sendMessage(prefix + ChatColor.GREEN + "&8-- &bServer Rules &8--");
+        int i = 1;
+        for (String rule : plugin.getConfig().getStringList("Rules")) {
+            sender.sendMessage(ChatColor.AQUA.toString() + i + ". " + ChatColor.translateAlternateColorCodes('&', rule));
+            i++;
+        }
+        sender.sendMessage(ChatColor.LIGHT_PURPLE + "Please note, these can change at any time.");
+        return false;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -14,6 +14,20 @@ WelcomeMessage:
   - "&9Join the Discord: /discord"
   - "&aPlayers online: &f%allplayers%"
 
+# Server Rules
+# Used in the /rules command.
+# Don't place bullet points or number rules, they are numbered automatically.
+# A header is also pre-filled, so do not include one.
+# Color codes supported here, guide: https://wiki.ess3.net/mc
+RulesMessage:
+  - "No Griefing: Griefing is against the rules unless you clean it up to what it was before."
+  - "No Hacking: Don't use hacked clients, x-ray, auto clickers, etc. Just don't."
+  - "Limit Swearing: Don't overdo it, I don't care about some light swearing but just keep it chill."
+  - "No Inappropriate Things: Art, text chat, voice chat, I don't really care, just keep it appropriate."
+  - "No Keeping Death Items: If you kill someone, you have to give their items back."
+  - "France isn't real: To play on the server you must accept that France isn't real."
+  - "Respect the faceless old woman who lives in your house and the creatures in your walls: Also, leave offerings for them."
+
 # France Joke
 # This is an inside joke on our server.
 # Disabled by default, change the below value to true to enable.

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -16,3 +16,5 @@ commands:
       - nnc
       - nonamecore
     description: Manage the No Name Core plugin.
+  rules:
+    description: Lists the rules for the server.


### PR DESCRIPTION
Created a command to list rules, intended for people not in the Discord server. Edit config.yml to change the rule list. Also, adds features to ManageCMD, such as reloading the plugin, as well as removing unneeded bloat and adding an unknown command message.

(i definitely didn't forget these in v1.0.1 part 1, what are you talking about?)